### PR TITLE
Update AKS cluster and ALB Controller setup

### DIFF
--- a/alb-namespace
+++ b/alb-namespace
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: alb-test-infra

--- a/application-load-balancer.yaml
+++ b/application-load-balancer.yaml
@@ -1,0 +1,8 @@
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: alb-test
+  namespace: alb-test-infra
+spec:
+  associations:
+  - $ALB_SUBNET_ID


### PR DESCRIPTION
This pull request includes various changes related to the ALB Controller installation, AKS cluster creation, and Kubernetes resource configuration. The most important changes include adding instructions and commands to verify the ALB Controller installation, creating a new AKS cluster with Azure CNI and workload identity enabled, and adding a new namespace called `alb-test-infra`.

Main changes:

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R80">`README.md`</a>: Added instructions and commands for verifying the ALB Controller installation, creating a new AKS cluster with Azure CNI and workload identity enabled, and updating the command to create the ApplicationLoadBalancer Kubernetes resource. <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R80">[1]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R12">[2]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R93-R94">[3]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R22">[4]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135-R143">[5]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R105-R118">[6]</a>
* <a href="diffhunk://#diff-df433a58ac21ae15e67a8a54387357553aeaa804900216b3dcb5ada1fe16cfa9R1-R4">`alb-namespace.yaml`</a>: Added a new namespace called `alb-test-infra`.
* <a href="diffhunk://#diff-16e006bbfd79f3fdba6f22743f53807ad86848a3b039a3ac2191241d97eb78d6R1-R8">`application-load-balancer.yaml`</a>: Added a new Kubernetes resource file defining an ApplicationLoadBalancer resource named `alb-test` in the `alb-test-infra` namespace.